### PR TITLE
[AWN-9344] Stop TLSProxy from exiting if host does not exist

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+hitch (1.4.6-1awn1) precise; urgency=low
+
+  * Fix issues with missing DNS names on startup
+
+ -- Arctic Wolf Networks Inc. Development <dev@arcticwolf.com>  Thu, 15 Feb 2018 15:27:00 +0000
+
 hitch (1.4.6-1awn0) precise; urgency=low
 
   * AWN package

--- a/src/hitch.c
+++ b/src/hitch.c
@@ -2763,24 +2763,8 @@ drop_privileges(void)
 void
 init_globals(void)
 {
-	/* backaddr */
-	struct addrinfo hints;
-	struct addrinfo *backaddr;
-
 	VTAILQ_INIT(&frontends);
 	VTAILQ_INIT(&worker_procs);
-
-	memset(&hints, 0, sizeof hints);
-	hints.ai_family = AF_UNSPEC;
-	hints.ai_socktype = SOCK_STREAM;
-	hints.ai_flags = 0;
-	const int gai_err = getaddrinfo(CONFIG->BACK_IP, CONFIG->BACK_PORT,
-	    &hints, &backaddr);
-	if (gai_err != 0) {
-		ERR("{getaddrinfo-backend}: %s\n", gai_strerror(gai_err));
-		exit(1);
-	}
-	freeaddrinfo(backaddr);
 
 #ifdef USE_SHARED_CACHE
 	if (CONFIG->SHARED_CACHE) {


### PR DESCRIPTION
Retry on every new connection to see if downstream host exists.

This fixes a race condition with DNS coming up the first time an
environment is created.

Tested: Brought up in my environment with bad hostname